### PR TITLE
Configures and enables CORS for API access

### DIFF
--- a/linktreeclone-backend/src/main/java/br/com/linktreeclone/config/SecurityConfig.java
+++ b/linktreeclone-backend/src/main/java/br/com/linktreeclone/config/SecurityConfig.java
@@ -17,6 +17,8 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
+import java.util.List;
+
 
 @Configuration
 @EnableWebSecurity
@@ -29,6 +31,7 @@ public class SecurityConfig
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception
     {
         http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/users/register",
@@ -48,12 +51,11 @@ public class SecurityConfig
     }
 
     @Bean
-    CorsConfigurationSource corsConfigurationSource()
-    {
+    public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("*"));
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowedOrigins(List.of("*"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD"));
+        configuration.setAllowedHeaders(List.of("*"));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;


### PR DESCRIPTION
Explicitly enables CORS support within the Spring Security filter chain. This ensures proper handling of cross-origin requests, allowing frontend applications from different origins to interact with the API.

Adds the `HEAD` method to the allowed CORS methods, enhancing compatibility for clients that use this method to check resource existence or retrieve headers without fetching the full response body.