### PR TITLE
Swagger UI

### DIFF
--- a/linktreeclone-backend/pom.xml
+++ b/linktreeclone-backend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.5</version>
+		<version>3.3.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>br.com</groupId>
@@ -92,6 +92,11 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
         </dependency>
 	</dependencies>
 

--- a/linktreeclone-backend/src/main/java/br/com/linktreeclone/config/SecurityConfig.java
+++ b/linktreeclone-backend/src/main/java/br/com/linktreeclone/config/SecurityConfig.java
@@ -38,6 +38,9 @@ public class SecurityConfig
                                 "/auth/login",
                                 "/status"
                         ).permitAll()
+                        .requestMatchers("/swagger-ui.html").permitAll()
+                        .requestMatchers("/swagger-ui/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/{username}").permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
This pull request introduces OpenAPI documentation support to the backend and adjusts project dependencies and security configuration accordingly. The main changes include adding the `springdoc-openapi` dependency, updating the Spring Boot version, and allowing unauthenticated access to API documentation endpoints.

**Dependency and Documentation Enhancements:**

* Added the `springdoc-openapi-starter-webmvc-ui` dependency (`version 2.5.0`) to enable OpenAPI (Swagger) documentation for the API.
* Downgraded the Spring Boot parent version from `3.5.5` to `3.3.0` in `pom.xml`, likely for compatibility with `springdoc-openapi`.

**Security Configuration Updates:**

* Updated `SecurityConfig.java` to permit unauthenticated access to `/swagger-ui.html`, `/swagger-ui/**`, and `/v3/api-docs/**` endpoints, allowing public access to API documentation.