### PR TITLE
Backend swagger front

### DIFF
--- a/linktreeclone-backend/pom.xml
+++ b/linktreeclone-backend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.5</version>
+		<version>3.3.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>br.com</groupId>
@@ -92,6 +92,11 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
         </dependency>
 	</dependencies>
 

--- a/linktreeclone-backend/src/main/java/br/com/linktreeclone/config/SecurityConfig.java
+++ b/linktreeclone-backend/src/main/java/br/com/linktreeclone/config/SecurityConfig.java
@@ -38,6 +38,9 @@ public class SecurityConfig
                                 "/auth/login",
                                 "/status"
                         ).permitAll()
+                        .requestMatchers("/swagger-ui.html").permitAll()
+                        .requestMatchers("/swagger-ui/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/{username}").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/linktreeclone-frontend/src/features/home/pages/HomePage.jsx
+++ b/linktreeclone-frontend/src/features/home/pages/HomePage.jsx
@@ -27,7 +27,7 @@ const HomePage = () => {
         };
 
         getStatus();
-    }, []); 
+    }, []);
 
     const isApiReady = apiStatus === 'ok';
 
@@ -40,15 +40,15 @@ const HomePage = () => {
             </p>
 
             <div className="home-cta-container">
-                <Link 
-                    to={isApiReady ? "/signup" : "#"} 
+                <Link
+                    to={isApiReady ? "/signup" : "#"}
                     className={`home-cta-button primary ${!isApiReady && 'disabled'}`}
                     style={{ pointerEvents: !isApiReady ? 'none' : 'auto' }} // Impede o clique
                 >
                     Criar minha página
                 </Link>
-                <Link 
-                    to={isApiReady ? "/login" : "#"} 
+                <Link
+                    to={isApiReady ? "/login" : "#"}
                     className={`home-cta-button secondary ${!isApiReady && 'disabled'}`}
                     style={{ pointerEvents: !isApiReady ? 'none' : 'auto' }}
                 >
@@ -74,6 +74,12 @@ const HomePage = () => {
                     Link do Repositório: {' '}
                     <a href="https://github.com/Cry199/Linktree-clone-Full-Stack" target="_blank" rel="noopener noreferrer">
                         GitHub
+                    </a>
+                </p>
+                <p>
+                    Backend (API): {' '}
+                    <a href="https://linktree-clone-api-faw777jkuq-rj.a.run.app/swagger-ui/index.html" target="_blank" rel="noopener noreferrer">
+                        Swagger UI
                     </a>
                 </p>
             </footer>


### PR DESCRIPTION
This pull request introduces OpenAPI/Swagger UI support to the backend and exposes its documentation in the frontend. It also adjusts the Spring Boot version and updates security settings to allow public access to the API docs. The most important changes are:

**Backend: OpenAPI Integration and Security**

* Added the `springdoc-openapi-starter-webmvc-ui` dependency to enable Swagger UI and OpenAPI documentation for the backend.
* Updated security configuration in `SecurityConfig.java` to publicly permit access to Swagger UI and OpenAPI endpoints (`/swagger-ui.html`, `/swagger-ui/**`, `/v3/api-docs/**`).

**Backend: Build Configuration**

* Downgraded the Spring Boot starter parent version from `3.5.5` to `3.3.0` in `pom.xml`.

**Frontend: Documentation Link**

* Added a link to the backend's Swagger UI documentation in the `HomePage` footer for easy API exploration.