### PR TITLE
feat(home): adiciona link para Swagger UI no rodapé da página inicial

### DIFF
--- a/linktreeclone-frontend/src/features/home/pages/HomePage.jsx
+++ b/linktreeclone-frontend/src/features/home/pages/HomePage.jsx
@@ -76,6 +76,12 @@ const HomePage = () => {
                         GitHub
                     </a>
                 </p>
+                <p>
+                    Backend (API): {' '}
+                    <a href="https://linktree-clone-api-faw777jkuq-rj.a.run.app/swagger-ui/index.html" target="_blank" rel="noopener noreferrer">
+                        Swagger UI
+                    </a>
+                </p>
             </footer>
         </div>
     );


### PR DESCRIPTION
This pull request introduces a small but useful addition to the `HomePage` component. It adds a link in the footer to the backend API's Swagger UI documentation, making it easier for users and developers to access the API reference.

- UI improvement:
  * Added a footer link to the backend (API) Swagger UI documentation in the `HomePage` component (`HomePage.jsx`).