### PR TITLE
Axios config

### DIFF
--- a/linktreeclone-backend/src/main/java/br/com/linktreeclone/exception/InvalidTokenException.java
+++ b/linktreeclone-backend/src/main/java/br/com/linktreeclone/exception/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package br.com.linktreeclone.exception;
+
+public class InvalidTokenException extends RuntimeException {
+  public InvalidTokenException(String message) {
+    super(message);
+  }
+}

--- a/linktreeclone-backend/src/main/java/br/com/linktreeclone/exception/InvalidTokenException.java
+++ b/linktreeclone-backend/src/main/java/br/com/linktreeclone/exception/InvalidTokenException.java
@@ -1,7 +1,8 @@
 package br.com.linktreeclone.exception;
 
-public class InvalidTokenException extends RuntimeException {
-  public InvalidTokenException(String message) {
-    super(message);
-  }
+public class InvalidTokenException extends RuntimeException
+{
+    public InvalidTokenException(String message) {
+        super(message);
+    }
 }

--- a/linktreeclone-backend/src/main/java/br/com/linktreeclone/exception/RestExceptionHandler.java
+++ b/linktreeclone-backend/src/main/java/br/com/linktreeclone/exception/RestExceptionHandler.java
@@ -38,4 +38,16 @@ public class RestExceptionHandler
 
         return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
     }
+
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidTokenException(InvalidTokenException ex, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.FORBIDDEN.value(),
+                "Forbidden",
+                ex.getMessage(),
+                request.getDescription(false).replace("uri=", "")
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
+    }
 }

--- a/linktreeclone-backend/src/main/java/br/com/linktreeclone/security/TokenService.java
+++ b/linktreeclone-backend/src/main/java/br/com/linktreeclone/security/TokenService.java
@@ -1,6 +1,7 @@
 package br.com.linktreeclone.security;
 
 import br.com.linktreeclone.entity.User;
+import br.com.linktreeclone.exception.InvalidTokenException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -53,7 +54,7 @@ public class TokenService
                     .getSubject();
         }
         catch (Exception e) {
-            throw new RuntimeException("Token JWT expirado ou inválido");
+            throw new InvalidTokenException("Token JWT expirado ou inválido");
         }
     }
 }

--- a/linktreeclone-frontend/src/api/axiosConfig.js
+++ b/linktreeclone-frontend/src/api/axiosConfig.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const apiClient = axios.create({
-  baseURL: 'https://linktree-clone-api-238899108893.southamerica-east1.run.app',
+  baseURL: 'https://linktree-clone-api-faw777jkuq-rj.a.run.app',
 });
 
 
@@ -14,5 +14,19 @@ apiClient.interceptors.request.use((config) => {
 }, (error) => {
   return Promise.reject(error);
 });
+
+apiClient.interceptors.response.use(
+  (response) => {
+    return response;
+  }, 
+  (error) => {
+    if (error.response && (error.response.status === 401 || error.response.status === 403)) {
+      localStorage.removeItem('authToken');
+      window.location.href = '/login'; 
+      console.log('Sessão expirada. Redirecionando para o login.');
+    }
+    return Promise.reject(error);
+  }
+);
 
 export default apiClient;


### PR DESCRIPTION
This pull request introduces improved error handling for invalid JWT tokens in the backend, and enhances the frontend to better handle authentication errors by redirecting users to the login page when their token is invalid or expired. Additionally, it updates the frontend API base URL.

**Backend: Improved Token Error Handling**

* Added a custom exception `InvalidTokenException` for clearer handling of invalid or expired JWT tokens. (`linktreeclone-backend/src/main/java/br/com/linktreeclone/exception/InvalidTokenException.java`, [linktreeclone-backend/src/main/java/br/com/linktreeclone/exception/InvalidTokenException.javaR1-R8](diffhunk://#diff-3bca1363f7a002bc765af7808a35fb93b8be42b3dda657b6a2940ad9d21446e3R1-R8))
* Updated the `TokenService` to throw `InvalidTokenException` instead of a generic `RuntimeException` when token validation fails. (`linktreeclone-backend/src/main/java/br/com/linktreeclone/security/TokenService.java`, [[1]](diffhunk://#diff-846147b42de08e7ffacab78c0185ca41ed15c94ab7720bad781fbbfbd410519bR4) [[2]](diffhunk://#diff-846147b42de08e7ffacab78c0185ca41ed15c94ab7720bad781fbbfbd410519bL56-R57)
* Modified `RestExceptionHandler` to handle `InvalidTokenException` and return a 403 Forbidden response with a descriptive error. (`linktreeclone-backend/src/main/java/br/com/linktreeclone/exception/RestExceptionHandler.java`, [linktreeclone-backend/src/main/java/br/com/linktreeclone/exception/RestExceptionHandler.javaR41-R52](diffhunk://#diff-9ad536e8fedd4165ea5b40006a48ca306ff2f7511e62bf2a88bd436cd077e5e4R41-R52))

**Frontend: Authentication Error Handling and Configuration**

* Updated the API base URL to the new backend endpoint. (`linktreeclone-frontend/src/api/axiosConfig.js`, [linktreeclone-frontend/src/api/axiosConfig.jsL4-R4](diffhunk://#diff-bc824b40f677f895cbf8197077e76742f88af873331153fc3d5007449ef35b0aL4-R4))
* Added a response interceptor to catch 401 and 403 errors, clear the authentication token, and redirect the user to the login page, improving the user experience on session expiry or invalid token. (`linktreeclone-frontend/src/api/axiosConfig.js`, [linktreeclone-frontend/src/api/axiosConfig.jsR18-R31](diffhunk://#diff-bc824b40f677f895cbf8197077e76742f88af873331153fc3d5007449ef35b0aR18-R31))