### PR TITLE
Update environment variables for backend deployment

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -39,8 +39,6 @@ jobs:
             --platform managed \
             --region southamerica-east1 \
             --allow-unauthenticated \
-            --set-env-vars="SPRING_DATASOURCE_URL=jdbc:postgresql://${{ secrets.IP_POSTGRES }}:5432/linktree_db?sslmode=require" \
-            --set-env-vars="SPRING_DATASOURCE_USERNAME=postgres" \
-            --set-env-vars="JWT_EXPIRATION=86400000" \
+            --set-env-vars="SPRING_DATASOURCE_URL=jdbc:postgresql://${{ secrets.IP_POSTGRES }}:5432/personal_finances_db?sslmode=require,SPRING_DATASOURCE_USERNAME=postgres,JWT_EXPIRATION=86400000" \
             --update-secrets=SPRING_DATASOURCE_PASSWORD=linktree-db-password:latest,JWT_SECRET=jwt-secret:latest \
             --quiet


### PR DESCRIPTION
This pull request updates the environment variable configuration for backend deployment in `.github/workflows/deploy-backend.yml`. The change consolidates multiple `--set-env-vars` commands into a single line and updates the database name used for the datasource connection.

Deployment configuration update:

* Changed the database name in the `SPRING_DATASOURCE_URL` from `linktree_db` to `personal_finances_db` and combined all environment variables into a single `--set-env-vars` command for improved clarity and maintainability.