### PR TITLE
Clean up LinktreecloneApplication.java formatting

### DIFF
--- a/linktreeclone-backend/src/main/java/br/com/linktreeclone/LinktreecloneApplication.java
+++ b/linktreeclone-backend/src/main/java/br/com/linktreeclone/LinktreecloneApplication.java
@@ -9,6 +9,4 @@ public class LinktreecloneApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(LinktreecloneApplication.class, args);
 	}
-
-	
 }


### PR DESCRIPTION
Removed unnecessary blank lines in the main application file.