### PR TITLE
Update database name in deployment workflow

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -39,6 +39,6 @@ jobs:
             --platform managed \
             --region southamerica-east1 \
             --allow-unauthenticated \
-            --set-env-vars="SPRING_DATASOURCE_URL=jdbc:postgresql://${{ secrets.IP_POSTGRES }}:5432/personal_finances_db?sslmode=require,SPRING_DATASOURCE_USERNAME=postgres,JWT_EXPIRATION=86400000" \
+            --set-env-vars="SPRING_DATASOURCE_URL=jdbc:postgresql://${{ secrets.IP_POSTGRES }}:5432/linktree_db?sslmode=require,SPRING_DATASOURCE_USERNAME=postgres,JWT_EXPIRATION=86400000" \
             --update-secrets=SPRING_DATASOURCE_PASSWORD=linktree-db-password:latest,JWT_SECRET=jwt-secret:latest \
             --quiet


### PR DESCRIPTION
This pull request updates the backend deployment workflow to use a different database for the application. The main change is switching the database name in the environment variable configuration.

Deployment configuration:

* Updated the `SPRING_DATASOURCE_URL` environment variable in `.github/workflows/deploy-backend.yml` to use the `linktree_db` database instead of `personal_finances_db`.